### PR TITLE
Extract tercen SDK into standalone tercen-rs crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,10 @@ on:
   push:
     branches: ['main', '*']
 
-# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
-# There are two jobs in this workflow: test (for Rust testing) and build-and-push-image (for Docker).
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -72,7 +70,6 @@ jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
     needs: test
-    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read
       packages: write
@@ -84,7 +81,6 @@ jobs:
         with:
           submodules: recursive
 
-      # Uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages.
       - name: Log in to the Container registry
         uses: docker/login-action@v3.3.0
         with:
@@ -92,32 +88,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # This step uses docker/metadata-action to extract tags and labels that will be applied to the specified image.
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5.5.1
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      # Set up Docker Buildx for advanced build features
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Build and push the Docker image
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v6.7.0
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           secrets: |
             gh_pat=${{ secrets.GH_PAT }}
 
-      # Generate artifact attestation
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Get short SHA
+        id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v6.7.0
@@ -99,6 +103,7 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.sha.outputs.short }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "tercen-rs"
 version = "0.1.0"
-source = "git+https://github.com/tercen/tercen-rs?branch=main#112126ec4cc68ccd754a2bc2127974f4b83f259a"
+source = "git+https://github.com/tercen/tercen-rs?branch=main#818fdf669ece4e1697ed2903fab4dd0aa7aef6ee"
 dependencies = [
  "base64",
  "futures",

--- a/operator.json
+++ b/operator.json
@@ -5,7 +5,7 @@
   "communicationProtocol": "grpc",
   "authors": ["Tercen"],
   "urls": ["https://github.com/tercen/ggrs_plot_operator"],
-  "container": "ghcr.io/tercen/ggrs_plot_operator:extract-tercen-rs",
+  "container": "ghcr.io/tercen/ggrs_plot_operator",
   "operatorSpec": {
     "kind": "OperatorSpec",
     "ontologyUri": "https://tercen.com/_ontology/tercen",


### PR DESCRIPTION
## Summary
- Extract the embedded `src/tercen/` module (21 files, ~7K lines) into standalone [`tercen-rs`](https://github.com/tercen/tercen-rs) crate
- Fix schema_ids retrieval: use `parentTaskId` instead of broken `model.taskId` path
- Remove `build.rs` and `tercen_grpc_api` submodule (proto compilation now handled by `tercen-rs`)
- Tag Docker images with commit SHA (full + short) and branch name for immutable resolution
- Remove explicit tag from `operator.json` container field — Tercen resolves it at install time

## Test plan
- [x] CI passes (test + build + push)
- [x] Install operator by commit SHA — container resolves to short SHA tag
- [x] Run operator on ClusterX test workflow — schema_ids retrieved via parentTaskId
- [x] Plot generated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)